### PR TITLE
kubernetes-intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # kirill-vlasov_platform
 kirill-vlasov Platform repository
+
+--- kubernetes-intro ---
+В этой домашней работе я выполнил следующие шаги:
+1. Развернул и запустил minikube (linux)
+2. Собрал и запушил docker образ [quickrestodocker/web:1.0](kubernetes-intro/web/Dockerfile)
+3. Создал конфигурационный файл [web-pod.yaml](kubernetes-intro/web-pod.yaml) для запуска этого проекта в minikube 
+4. После запуска все собралось, проинициализировалось (initContainers), пробросил порты и проверил работу - отобразился 
+index.html c космическим кораблем 42 :)
+5. Скачал и собрал образ frontend для проекта hipster stop, запушил в докерхаб.
+6. Запустил через kubectl run, поймал ошибку старта pod
+7. Сформировал [frontend-pod-healthy.yaml](kubernetes-intro/frontend-pod-healthy.yaml) для корректного запуска.
+По логам пода ясно, что приложение крешится из-за отсутствия необходимых переменных окружения. Соответственно в 
+новом конфигурационном файле они добавлены. 
+8. Применил (kubectl apply) файл frontend-pod-healthy.yaml, pod стартовал.

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      serviceAccountName: default
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+          image: quickrestodocker/hipster-frontend
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-readiness-probe"
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-liveness-probe"
+          env:
+            - name: PORT
+              value: "8080"
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: "productcatalogservice:3550"
+            - name: CURRENCY_SERVICE_ADDR
+              value: "currencyservice:7000"
+            - name: CART_SERVICE_ADDR
+              value: "cartservice:7070"
+            - name: RECOMMENDATION_SERVICE_ADDR
+              value: "recommendationservice:8080"
+            - name: SHIPPING_SERVICE_ADDR
+              value: "shippingservice:50051"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkoutservice:5050"
+            - name: AD_SERVICE_ADDR
+              value: "adservice:9555"
+            - name: ENABLE_PROFILER
+              value: "0"

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    key: value
+spec:
+  containers:
+    - name: web
+      image: quickrestodocker/web:1.0
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-index-html
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: web
   labels:
-    key: value
+    app: nginx
 spec:
   containers:
     - name: web

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:centos7
+RUN mkdir /app/
+RUN yum -y install epel-release
+RUN yum -y install nginx
+RUN usermod -u 1001 nginx && groupmod -g 1001 nginx
+ADD nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,28 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    keepalive_timeout  65;
+    server {
+        listen       8000;
+        server_name  localhost;
+        location / {
+            root   /app;
+            index  index.html index.htm;
+        }
+    }
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [V] Основное ДЗ
 - [V] Задание со *

## В процессе сделано:
1. Развернул и запустил minikube (linux)
2. Собрал и запушил docker образ [quickrestodocker/web:1.0](kubernetes-intro/web/Dockerfile)
3. Создал конфигурационный файл [web-pod.yaml](kubernetes-intro/web-pod.yaml) для запуска этого проекта в minikube 
4. После запуска все собралось, проинициализировалось (initContainers), пробросил порты и проверил работу - отобразился 
index.html c космическим кораблем 42 :)
5. Скачал и собрал образ frontend для проекта hipster stop, запушил в докерхаб.
6. Запустил через kubectl run, поймал ошибку старта pod
7. Сформировал [frontend-pod-healthy.yaml](kubernetes-intro/frontend-pod-healthy.yaml) для корректного запуска.
По логам пода ясно, что приложение крешится из-за отсутствия необходимых переменных окружения. Соответственно в 
новом конфигурационном файле они добавлены. 
8. Применил (kubectl apply) файл frontend-pod-healthy.yaml, pod стартовал.


## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания


Minikube создает docker контейнер с инфраструктурой для работы k8s, по сути - docker in docker, где поды и необходимые сервисы работают как docker контейнеры. 
Соответственно, если удалить или остановить запущенные контейнеры - minikube отслеживает этот статус и перезапускает или пересоздает все в изначальное состояние.
Пока могу только предположить, что существует какой-то главный супервизорный процесс, который мониторит состояние docker контейнеров, возможно это kubelet.