### PR TITLE
kubernetes-volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,49 @@ index.html c космическим кораблем 42 :)
 По логам пода ясно, что приложение крешится из-за отсутствия необходимых переменных окружения. Соответственно в 
 новом конфигурационном файле они добавлены. 
 8. Применил (kubectl apply) файл frontend-pod-healthy.yaml, pod стартовал.
+
+
+# Выполнено ДЗ №4
+
+- [V] Основное ДЗ kubernetes-volumes
+- [V] Задание со *
+
+## В процессе сделано:
+- Запустил кластер инструментом kind
+- Применил конфигурацию StatefulSet из файла [minio-statefulset.yaml](kubernetes-volumes%2Fminio-statefulset.yaml)
+- Применил конфигурацию для создания сервиса [minio-headlessservice.yaml](kubernetes-volumes%2Fminio-headlessservice.yaml)
+- В результате запустился statefulset `minio`:
+```
+❯ kubectl get statefulsets
+NAME    READY   AGE
+minio   1/1     3h10m
+```
+сервис:
+```
+❯ kubectl get pods
+NAME      READY   STATUS    RESTARTS   AGE
+minio-0   1/1     Running   0          7m21s
+```
+
+persistent volume claim:
+```
+❯ kubectl get pvc
+NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-minio-0   Bound    pvc-517361d2-387f-4045-90c0-f4c1f5fc1dd8   10Gi       RWO            standard       3h11m
+```
+и persistent volume:
+```
+❯ kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+pvc-517361d2-387f-4045-90c0-f4c1f5fc1dd8   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                3h11m
+```
+- Создал файл конфигурации секретов для stateful set minio [minio-secrets.yaml](kubernetes-volumes%2Fminio-secrets.yaml) 
+- Обновил файл [minio-statefulset.yaml](kubernetes-volumes%2Fminio-statefulset.yaml) добавив изменения по заданию
+- Применил файл секретов и файл для stateful set
+- Проверил, что секреты стали видны в переменных окружения сервиса:
+```
+  ❯ kubectl exec -it minio-0 bash -- /bin/sh -c 'echo $MINIO_ACCESS_KEY'
+  minio
+  ❯ kubectl exec -it minio-0 bash -- /bin/sh -c 'echo $MINIO_SECRET_KEY'
+  minio123
+```

--- a/kubernetes-volumes/minio-headlessservice.yaml
+++ b/kubernetes-volumes/minio-headlessservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secrets.yaml
+++ b/kubernetes-volumes/minio-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+data:
+  accessKey: bWluaW8K
+  secretKey: bWluaW8xMjMK

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+        - name: minio
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: accessKey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: secretKey
+          image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+          args:
+            - server
+            - /data
+          ports:
+            - containerPort: 9000
+          # These volume mounts are persistent. Each pod in the PetSet
+          # gets a volume mounted based on this field.
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Liveness probe detects situations where MinIO server instance
+          # is not working properly and needs restart. Kubernetes automatically
+          # restarts the pods if liveness checks fail.
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 120
+            periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №4

- [V] Основное ДЗ kubernetes-volumes
- [V] Задание со *

## В процессе сделано:
- Запустил кластер инструментом kind
- Применил конфигурацию StatefulSet из файла [minio-statefulset.yaml](kubernetes-volumes%2Fminio-statefulset.yaml)
- Применил конфигурацию для создания сервиса [minio-headlessservice.yaml](kubernetes-volumes%2Fminio-headlessservice.yaml)
- В результате запустился statefulset `minio`:
```
❯ kubectl get statefulsets
NAME    READY   AGE
minio   1/1     3h10m
```
сервис:
```
❯ kubectl get pods
NAME      READY   STATUS    RESTARTS   AGE
minio-0   1/1     Running   0          7m21s
```

persistent volume claim:
```
❯ kubectl get pvc
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-minio-0   Bound    pvc-517361d2-387f-4045-90c0-f4c1f5fc1dd8   10Gi       RWO            standard       3h11m
```
и persistent volume:
```
❯ kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
pvc-517361d2-387f-4045-90c0-f4c1f5fc1dd8   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                3h11m
```
- Создал файл конфигурации секретов для stateful set minio [minio-secrets.yaml](kubernetes-volumes%2Fminio-secrets.yaml) 
- Обновил файл [minio-statefulset.yaml](kubernetes-volumes%2Fminio-statefulset.yaml) добавив изменения по заданию
- Применил файл секретов и файл для stateful set
- Проверил, что секреты стали видны в переменных окружения сервиса:
```
  ❯ kubectl exec -it minio-0 bash -- /bin/sh -c 'echo $MINIO_ACCESS_KEY'
  minio
  ❯ kubectl exec -it minio-0 bash -- /bin/sh -c 'echo $MINIO_SECRET_KEY'
  minio123
```
